### PR TITLE
Add tests, allow undeclared parameters, refactor spin

### DIFF
--- a/kinesis_video_streamer/CMakeLists.txt
+++ b/kinesis_video_streamer/CMakeLists.txt
@@ -57,6 +57,9 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME
   DESTINATION lib/${PROJECT_NAME})
 
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
 #############
 ## Tests ##
 #############
@@ -76,6 +79,15 @@ target_include_directories(test_streamer_node
   PRIVATE include ${KPL_INCLUDES_PATH}
   ${kinesis_manager_INCLUDE_DIRS})
 target_link_libraries(test_streamer_node
+        ${PROJECT_NAME}_lib
+        ${LIB_DEPS})
+
+ament_add_gmock(test_subscriber_callbacks
+  test/subscriber_callbacks_test.cpp)
+target_include_directories(test_subscriber_callbacks
+  PRIVATE include ${KPL_INCLUDES_PATH}
+  ${kinesis_manager_INCLUDE_DIRS})
+target_link_libraries(test_subscriber_callbacks
         ${PROJECT_NAME}_lib
         ${LIB_DEPS})
 

--- a/kinesis_video_streamer/CMakeLists.txt
+++ b/kinesis_video_streamer/CMakeLists.txt
@@ -57,7 +57,6 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME
   DESTINATION lib/${PROJECT_NAME})
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
 #############

--- a/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
+++ b/kinesis_video_streamer/include/kinesis_video_streamer/streamer.h
@@ -32,7 +32,9 @@ constexpr uint32_t kDefaultNumberOfSpinnerThreads = 1;
 class StreamerNode : public rclcpp::Node
 {
 public:
-  StreamerNode(const std::string & name, const std::string & ns = std::string());
+  StreamerNode(const std::string & name,
+               const std::string & ns,
+               const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   ~StreamerNode() = default;
 
@@ -40,8 +42,6 @@ public:
                                   std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer);
 
   KinesisManagerStatus InitializeStreamSubscriptions();
-
-  void Spin();
 
 private:
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader_;

--- a/kinesis_video_streamer/src/streamer.cpp
+++ b/kinesis_video_streamer/src/streamer.cpp
@@ -28,13 +28,13 @@
 #include <kinesis_video_streamer/streamer.h>
 
 using namespace Aws::Client;
-const char * kSpinnerThreadCountOverrideParameter = "spinner_thread_count";
 
 namespace Aws {
 namespace Kinesis {
 
     StreamerNode::StreamerNode(const std::string & name,
-                 const std::string & ns) : rclcpp::Node(name, ns) {}
+                               const std::string & ns,
+                               const rclcpp::NodeOptions & options) : rclcpp::Node(name, ns, options) {}
 
     KinesisManagerStatus StreamerNode::Initialize(std::shared_ptr<Aws::Client::Ros2NodeParameterReader> parameter_reader,
                                                   std::shared_ptr<RosStreamSubscriptionInstaller> subscription_installer)
@@ -88,19 +88,6 @@ namespace Kinesis {
             return streamer_setup_result;
         }
         return KINESIS_MANAGER_STATUS_SUCCESS;
-    }
-
-    void StreamerNode::Spin()
-    {
-        uint32_t spinner_thread_count = kDefaultNumberOfSpinnerThreads;
-        int spinner_thread_count_input;
-        if (Aws::AwsError::AWS_ERR_OK ==
-            parameter_reader_->ReadParam(ParameterPath(kSpinnerThreadCountOverrideParameter),
-                                         spinner_thread_count_input)) {
-            spinner_thread_count = static_cast<uint32_t>(spinner_thread_count_input);
-        }
-        rclcpp::executors::MultiThreadedExecutor spinner(rclcpp::executor::ExecutorArgs(), spinner_thread_count);
-        spinner.spin();
     }
 
 }  // namespace Kinesis

--- a/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
@@ -372,7 +372,7 @@ void RunTest()
             rostopic_list_output += buffer.data();
         }
     }
-    ASSERT_EQ(rostopic_list_output, expected_rostopic_list_output);
+    EXPECT_EQ(rostopic_list_output, expected_rostopic_list_output);
 }
 
 RosStreamSubscriptionInstaller * real_subscription_installer;

--- a/kinesis_video_streamer/test/streamer_node_test.cpp
+++ b/kinesis_video_streamer/test/streamer_node_test.cpp
@@ -44,10 +44,13 @@ protected:
   std::shared_ptr<MockRosStreamSubscriptionInstaller> mock_subscription_installer_;
   std::shared_ptr<StreamerNode> streamer_node_;
   std::shared_ptr<Aws::Client::Ros2NodeParameterReader> parameter_reader_;
+  rclcpp::NodeOptions node_options_;
 
   void SetUp() override
   {
-    streamer_node_ = std::make_shared<StreamerNode>("streamer");
+    node_options_.allow_undeclared_parameters(true);
+    node_options_.automatically_declare_parameters_from_overrides(true);
+    streamer_node_ = std::make_shared<StreamerNode>("streamer", std::string(), node_options_);
     parameter_reader_ = std::make_shared<Aws::Client::Ros2NodeParameterReader>(streamer_node_);
     mock_subscription_installer_ = std::make_shared<MockRosStreamSubscriptionInstaller>(streamer_node_);
   }
@@ -69,7 +72,6 @@ TEST_F(TestStreamerNode, InitializeStreamerNode)
   EXPECT_EQ(initialize_result, KINESIS_MANAGER_STATUS_INVALID_INPUT);
   /* Set the region and expect success */
   rclcpp::Parameter region("aws_client_configuration.region", "not-empty");
-  streamer_node_->declare_parameter("aws_client_configuration.region");
   streamer_node_->set_parameters({region});
   initialize_result = streamer_node_->Initialize(parameter_reader_, mock_subscription_installer_);
   EXPECT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(initialize_result));

--- a/kinesis_video_streamer/test/subscriber_callbacks_test.cpp
+++ b/kinesis_video_streamer/test/subscriber_callbacks_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws_ros2_common/sdk_utils/logging/aws_ros_logger.h>
+#include <kinesis_manager/kinesis_stream_manager.h>
+#include <kinesis_manager/stream_definition_provider.h>
+#include "kinesis_video_msgs/msg/kinesis_video_frame.hpp"
+#include <kinesis_video_streamer/ros_stream_subscription_installer.h>
+#include <kinesis_video_streamer/streamer.h>
+#include <kinesis_video_streamer/subscriber_callbacks.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <queue>
+#include <gmock/gmock.h>
+
+#include "kinesis_video_streamer_test_utils.h"
+
+using namespace std;
+using namespace Aws::Client;
+using namespace Aws::Kinesis;
+using namespace Aws::Utils::Logging;
+
+TestData * kTestData = nullptr;
+AWSROSLogger * kLogger;
+
+class MockKinesisStreamManager : public KinesisStreamManagerInterface
+{
+public:
+  MockKinesisStreamManager(const Aws::Client::ParameterReaderInterface * parameter_reader,
+                                const StreamDefinitionProvider * stream_definition_provider,
+                                StreamSubscriptionInstaller * subscription_installer) : KinesisStreamManagerInterface(parameter_reader,
+ stream_definition_provider, subscription_installer) {}
+
+  MOCK_METHOD2(ProcessCodecPrivateDataForStream, KinesisManagerStatus(const std::string & stream_name, std::vector<uint8_t> codec_private_data));
+  MOCK_CONST_METHOD2(PutFrame, KinesisManagerStatus(std::string stream_name, Frame & frame));
+  MOCK_CONST_METHOD2(PutMetadata, KinesisManagerStatus(std::string stream_name, const std::string & name, const std::string & value));
+};
+
+
+class SubscriberCallbacksTestBase : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        handle = rclcpp::Node::make_shared("test_node");
+        kTestData = &test_data;
+        stream_definition_provider = new MockStreamDefinitionProvider(&test_data);
+        subscription_installer =
+                new MockStreamSubscriptionInstaller(&test_data, *stream_manager, handle);
+        stream_manager = new MockKinesisStreamManager(&test_data, &parameter_reader,
+                                                      stream_definition_provider, subscription_installer);
+        subscription_installer->set_stream_manager(stream_manager);
+    }
+
+    void TearDown() override
+    {
+        delete stream_manager;
+        delete stream_definition_provider;
+        delete subscription_installer;
+    }
+
+    std::shared_ptr<rclcpp::Node> handle;
+    TestParameterReader parameter_reader;
+    TestData test_data;
+    MockKinesisStreamManager * stream_manager;
+    StreamDefinitionProvider real_stream_definition_provider;
+    MockStreamDefinitionProvider * stream_definition_provider;
+    MockStreamSubscriptionInstaller * subscription_installer;
+};
+
+/**
+ * Tests success scenario.
+ */
+TEST_F(SubscriberCallbacksTestBase, KinesisVideoFrameTransportCallbackTest)
+{
+    kinesis_video_msgs::msg::KinesisVideoFrame message;
+    KinesisVideoFrameTransportCallback(stream_manager, "stream_name", message);
+    /* Shouldn't process codec data as the message is empty */
+    EXPECT_CALL(stream_manager, ProcessCodecPrivateDataForStream()).Times(0);
+}
+
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    rclcpp::init(argc, argv);
+//    auto node = rclcpp::Node::make_shared("test_kinesis_video_streamer");
+//    AWSROSLogger logger(LogLevel::Trace, node);
+//    kLogger = &logger;
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}


### PR DESCRIPTION
* Add subscriber_callbacks_test.cpp to increase coverage
* Allow undeclared parameters
* Move spin into main - AFAIK a node can't spin itself like it used to in ROS1 (might be able to store a shared ptr into the underlying `Node` from `StreamerNode`, but that's ugly)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
