### PR TITLE
Increase test stability by waiting for callbacks longer

### DIFF
--- a/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
+++ b/kinesis_video_streamer/test/kinesis_video_streamer_test.cpp
@@ -43,6 +43,7 @@ constexpr chrono::nanoseconds kLongCallbackWaitTime = chrono::duration_cast<chro
       if (!(expr)) {                                            \
         rclcpp::executors::SingleThreadedExecutor executor;     \
         executor.add_node(handle);                              \
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000)); \
         executor.spin_some();                                   \
         if (!(expr)) {                                          \
             executor.spin_once(kShortCallbackWaitTime);         \
@@ -259,7 +260,7 @@ void RunTest()
     test_data.get_stream_definition_return_value = (StreamDefinition *)stream_definition.release();
     KinesisManagerStatus setup_result = stream_manager->KinesisVideoStreamerSetup();
     ASSERT_TRUE(KINESIS_MANAGER_STATUS_SUCCEEDED(setup_result));
-    int publish_call_count = kDefaultMessageQueueSize;
+    int publish_call_count = kDefaultMessageQueueSize / 2;
     rmw_qos_profile_t rmw_qos_settings = rmw_qos_profile_default;
     rmw_qos_settings.depth = kDefaultMessageQueueSize;
     auto kinesis_video_frame_publisher = handle->create_publisher<kinesis_video_msgs::msg::KinesisVideoFrame>(subscription_topic_name, rmw_qos_settings);


### PR DESCRIPTION
On slower machine (e.g. Travis) the callbacks are not being called fast enough. The test code asserts that X number of calls were performed and fails.
 
Reproduced travis-like performance with `stress --cpu 5 --io 2 --timeout 30s` and saw the tests fail. After this addition they pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
