### PR TITLE
Add test dependency on ros2topic

### DIFF
--- a/kinesis_video_streamer/package.xml
+++ b/kinesis_video_streamer/package.xml
@@ -20,7 +20,8 @@
   <exec_depend>rmw_implementation</exec_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
-
+  <test_depend>ros2topic</test_depend>
+ 
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
The test executes `ros2 topic list` to check that a topic exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
