### PR TITLE
Add ability to set AWS Region and stream name via launch parameters

### DIFF
--- a/kinesis_video_streamer/config/sample_config.yaml
+++ b/kinesis_video_streamer/config/sample_config.yaml
@@ -31,11 +31,11 @@ kinesis_video_streamer:
         # 3: Like 1 but with AWS Rekognition support built-in. Results will be read from 'rekognition_data_stream' and published onto 'rekognition_topic_name'.
         topic_type: 1
 
-        #### If topic_type is not 3, the following parameters will have no effect.
+        #### If topic_type is 3, we expect the following parameters.
         ### The Kinesis Data Stream from which to read Rekognition's analysis results.
-        rekognition_data_stream: "kinesis-sample"
+        # rekognition_data_stream: "kinesis-sample"
         ### The ROS topic on which to publish the results.
-        rekognition_topic_name: "/rekognition/results"
+        # rekognition_topic_name: "/rekognition/results"
 
         # Frame rate should match the encoder's (and the camera's) frame rate.
         frame_rate: 30

--- a/kinesis_video_streamer/config/sample_config.yaml
+++ b/kinesis_video_streamer/config/sample_config.yaml
@@ -31,11 +31,11 @@ kinesis_video_streamer:
         # 3: Like 1 but with AWS Rekognition support built-in. Results will be read from 'rekognition_data_stream' and published onto 'rekognition_topic_name'.
         topic_type: 1
 
-        #### If topic_type is 3, we expect the following parameters.
+        #### If topic_type is not 3, the following parameters will have no effect.
         ### The Kinesis Data Stream from which to read Rekognition's analysis results.
-        # rekognition_data_stream: "kinesis-sample"
+        rekognition_data_stream: "kinesis-sample"
         ### The ROS topic on which to publish the results.
-        # rekognition_topic_name: "/rekognition/results"
+        rekognition_topic_name: "/rekognition/results"
 
         # Frame rate should match the encoder's (and the camera's) frame rate.
         frame_rate: 30

--- a/kinesis_video_streamer/launch/kinesis_video_streamer.launch.py
+++ b/kinesis_video_streamer/launch/kinesis_video_streamer.launch.py
@@ -21,19 +21,16 @@ import shutil
 # Argument names
 NODE_NAME = "node_name"
 CONFIG = "config"
+AWS_REGION = "aws_region"
+STREAM_NAME = "stream_name"
+
 MAX_STRING_LEN = 128
 
-def get_logger_config_path():
+def get_logger_config_path(config_yaml):
   logger_config_path = os.path.join(get_package_share_directory('kinesis_video_streamer'),
     'config', 'kvs_log_configuration')
-  default_config = os.path.join(get_package_share_directory('kinesis_video_streamer'),
-    'config', 'sample_config.yaml')
-
-  with open(default_config, 'r') as f:
-      config_text = f.read()
-  config_yaml = yaml.safe_load(config_text)
-
   fallback_path = '/tmp/kvs_log_configuration'
+
   if fallback_path == config_yaml['kinesis_video_streamer']['ros__parameters']['kinesis_video']['log4cplus_config']:
     if len(logger_config_path) <= MAX_STRING_LEN:
       # Override /tmp/... to the actual path
@@ -51,6 +48,13 @@ def generate_launch_description():
   default_config = os.path.join(get_package_share_directory('kinesis_video_streamer'),
     'config', 'sample_config.yaml')
 
+  with open(default_config, 'r') as f:
+      config_text = f.read()
+  config_yaml = yaml.safe_load(config_text)
+
+  default_aws_region = config_yaml['kinesis_video_streamer']['ros__parameters']['aws_client_configuration']['region']
+  default_stream_name = config_yaml['kinesis_video_streamer']['ros__parameters']['kinesis_video']['stream0']['stream_name']
+
   ld = launch.LaunchDescription([
     launch.actions.DeclareLaunchArgument(
       NODE_NAME,
@@ -59,14 +63,36 @@ def generate_launch_description():
     launch.actions.DeclareLaunchArgument(
       CONFIG,
       default_value=default_config
+    ),
+    launch.actions.DeclareLaunchArgument(
+      AWS_REGION,
+      default_value=default_aws_region
+    ),
+    launch.actions.DeclareLaunchArgument(
+      STREAM_NAME,
+      default_value=default_stream_name
     )
    ])
 
-  logger_config_path = get_logger_config_path()
-  if logger_config_path is None:
-    node_parameters = [launch.substitutions.LaunchConfiguration(CONFIG)]
-  else:
-    node_parameters = [launch.substitutions.LaunchConfiguration(CONFIG), {'log4cplus_config': logger_config_path}]
+  node_parameters = [launch.substitutions.LaunchConfiguration(CONFIG)]
+  node_parameters.append({
+    'aws_client_configuration': {
+      'region': launch.substitutions.LaunchConfiguration(AWS_REGION)
+    },
+    'kinesis_video': {
+      'stream0': {
+        'stream_name': launch.substitutions.LaunchConfiguration(STREAM_NAME)
+      }
+    }
+  })
+  logger_config_path = get_logger_config_path(config_yaml)
+  if logger_config_path is not None:
+    node_parameters.append({
+      'kinesis_video': {
+        'log4cplus_config': logger_config_path
+      }
+    })
+
   streamer_node = launch_ros.actions.Node(
     package="kinesis_video_streamer",
     node_executable="kinesis_video_streamer",


### PR DESCRIPTION
*Description of changes:*

Currently, the AWS region and stream name of the default stream (`stream0`) can only be set via the config YAML file. This change adds the ability to set these via "ros2 launch" parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.