### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/kinesis_video_msgs/package.xml
+++ b/kinesis_video_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <package format="3">
   <name>kinesis_video_msgs</name>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <description>Messages for transmitting video frames to Kinesis Video Streams.</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>


### PR DESCRIPTION
*Issue #, if available:*
All packages in a repo need to have the same version number.  This is necessary because of this change https://github.com/aws-robotics/kinesisvideo-ros2/pull/21
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
